### PR TITLE
FileSystem to be chosen based on the file system of Input Path A.

### DIFF
--- a/bigfiles/src/main/scala/za/co/absa/parser/ArgsParser.scala
+++ b/bigfiles/src/main/scala/za/co/absa/parser/ArgsParser.scala
@@ -83,7 +83,8 @@ object ArgsParser {
     */
   def validate(args: Arguments)(implicit spark: SparkSession): Boolean = {
     val config = spark.sparkContext.hadoopConfiguration
-    val fs     = FileSystem.get(config)
+    val fsFilePath = new Path(args.inputA)
+    val fs = fsFilePath.getFileSystem(config)
     if (!fs.exists(new Path(args.inputA))) throw new IllegalArgumentException(s"Input ${args.inputA} does not exist")
     if (!fs.exists(new Path(args.inputB))) throw new IllegalArgumentException(s"Input ${args.inputB} does not exist")
     if (fs.exists(new Path(args.out))) throw new IllegalArgumentException(s"Output ${args.out} already exist")


### PR DESCRIPTION
This pull request makes a targeted change to the way the Hadoop `FileSystem` is instantiated in the `ArgsParser` utility. Instead of using the default file system from the Hadoop configuration, it now determines the file system based on the input path, which improves compatibility with multiple file system schemes (e.g., local, HDFS, S3).

## Overview

<!-- Summarize the key changes for release notes. -->
## Release Notes
- Use correct fs instance when validating input parameter

